### PR TITLE
Zero-shot demo

### DIFF
--- a/demo_zero.py
+++ b/demo_zero.py
@@ -119,7 +119,7 @@ def demo(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser('DAVE', parents=[get_argparser()])
     parser.add_argument('--img_path', type=Path)
-    parser.add_argument('--out_path', type=Path)
+    parser.add_argument('--out_path', type=Path, default="material")
     parser.add_argument('--show', action='store_true')
     parser.add_argument('--two_passes', action='store_true')
     args = parser.parse_args()

--- a/demo_zero.py
+++ b/demo_zero.py
@@ -36,7 +36,7 @@ def demo(args):
     device = torch.device(gpu)
 
     model = DataParallel(
-        build_model(args, is_zero_demo=True).to(device),
+        build_model(args).to(device),
         device_ids=[gpu],
         output_device=gpu
     )
@@ -49,12 +49,13 @@ def demo(args):
     model.module.feat_comp.load_state_dict(pretrained_dict_feat)
     model.eval()
 
+    bboxes = torch.zeros((1, 3, 4))
+
     def one_img(img_path):
         scale_x = scale_y = 1
         image = Image.open(img_path).convert("RGB")
         img, scale = resize(image, args.image_size)
         img = img.unsqueeze(0).to(device)
-        bboxes = torch.tensor([]).unsqueeze(0).to(device)
 
         denisty_map, _, _, predicted_bboxes = model(img, bboxes=bboxes)
 

--- a/demo_zero.py
+++ b/demo_zero.py
@@ -1,0 +1,126 @@
+import argparse
+from pathlib import Path
+import os
+import torch
+from torch.nn import DataParallel
+from torchvision import transforms as T
+from PIL import Image
+import matplotlib.pyplot as plt
+from tqdm import tqdm
+
+from utils.arg_parser import get_argparser
+from models.dave import build_model
+from utils.data import pad_image
+
+
+def resize(img, img_size):
+    resize_img = T.Resize((img_size, img_size), antialias=True)
+    w, h = img.size
+    img = T.Compose([
+        T.ToTensor(),
+        resize_img,
+        T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+    ])(img)
+    scale = torch.tensor([1.0, 1.0]) / torch.tensor([w, h]) * img_size
+    return img, scale
+
+
+@torch.no_grad()
+def demo(args):
+    global fig, ax
+
+    dpi = plt.rcParams['figure.dpi']
+    plt.figure()
+    gpu = 0
+    torch.cuda.set_device(gpu)
+    device = torch.device(gpu)
+
+    model = DataParallel(
+        build_model(args, is_zero_demo=True).to(device),
+        device_ids=[gpu],
+        output_device=gpu
+    )
+    model.load_state_dict(
+        torch.load(os.path.join(args.model_path, 'DAVE_0_shot.pth'))['model'], strict=False
+    )
+    pretrained_dict_feat = {k.split("feat_comp.")[1]: v for k, v in
+                            torch.load(os.path.join(args.model_path, 'verification.pth'))[
+                                'model'].items() if 'feat_comp' in k}
+    model.module.feat_comp.load_state_dict(pretrained_dict_feat)
+    model.eval()
+
+    def one_img(img_path):
+        scale_x = scale_y = 1
+        image = Image.open(img_path).convert("RGB")
+        img, scale = resize(image, args.image_size)
+        img = img.unsqueeze(0).to(device)
+        bboxes = torch.tensor([]).unsqueeze(0).to(device)
+
+        denisty_map, _, _, predicted_bboxes = model(img, bboxes=bboxes)
+
+        if args.two_passes:
+            boxes_predicted = predicted_bboxes.box
+            scale_y = min(1, 50 / (boxes_predicted[:, 2] - boxes_predicted[:, 0]).mean())
+            scale_x = min(1, 50 / (boxes_predicted[:, 3] - boxes_predicted[:, 1]).mean())
+
+            if scale_x < 1 or scale_y < 1:
+                scale_x = (int(args.image_size * scale_x) // 8 * 8) / args.image_size
+                scale_y = (int(args.image_size * scale_y) // 8 * 8) / args.image_size
+                resize_ = T.Resize((int(args.image_size * scale_x), int(args.image_size * scale_y)), antialias=True)
+                img_resized = resize_(img)
+
+                img_resized = pad_image(img_resized[0]).unsqueeze(0)
+
+            else:
+                scale_y = max(1, 11 / (boxes_predicted[:, 2] - boxes_predicted[:, 0]).mean())
+                scale_x = max(1, 11 / (boxes_predicted[:, 3] - boxes_predicted[:, 1]).mean())
+
+                if scale_y > 1.9:
+                    scale_y = 1.9
+                if scale_x > 1.9:
+                    scale_x = 1.9
+
+                scale_x = (int(args.image_size * scale_x) // 8 * 8) / args.image_size
+                scale_y = (int(args.image_size * scale_y) // 8 * 8) / args.image_size
+                resize_ = T.Resize((int(args.image_size * scale_x), int(args.image_size * scale_y)), antialias=True)
+                img_resized = resize_(img)
+
+            if scale_x != 1.0 or scale_y != 1.0:
+                denisty_map, _, _, predicted_bboxes = model(img_resized, bboxes)
+
+        pred_boxes = predicted_bboxes.box.cpu() / torch.tensor([scale_y*scale[0], scale_x*scale[1], scale_y*scale[0], scale_x*scale[1]])
+
+        plt.clf()
+        w, h = image.size
+        figsize = (w + 100) / float(dpi), (h + 100) / float(dpi)
+        plt.rcParams["figure.figsize"] = figsize
+        plt.imshow(image)
+        for i in range(len(pred_boxes)):
+            box = pred_boxes[i]
+            plt.plot([box[0], box[0], box[2], box[2], box[0]], [box[1], box[3], box[3], box[1], box[1]], linewidth=2,
+                    color='red')
+        plt.title("Dmap count:" + str(round(denisty_map.sum().item(), 1)) + " Box count:" + str(len(pred_boxes)))
+        if args.show:
+            plt.show()
+        else:
+            out_file = args.out_path / f"{img_path.stem}__out.png"
+            plt.savefig(out_file, bbox_inches='tight')
+
+    if args.img_path.is_file():
+        one_img(args.img_path)
+    elif args.img_path.is_dir():
+        for img_p in (imgs := tqdm(list(args.img_path.iterdir()))):
+            imgs.set_description(f"{img_p.name:>30}")
+            one_img(img_p)
+    else:
+        raise(ValueError, f"{args.img_path} is neither a dir nor a file :(")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser('DAVE', parents=[get_argparser()])
+    parser.add_argument('--img_path', type=Path)
+    parser.add_argument('--out_path', type=Path)
+    parser.add_argument('--show', action='store_true')
+    parser.add_argument('--two_passes', action='store_true')
+    args = parser.parse_args()
+    demo(args)

--- a/models/dave.py
+++ b/models/dave.py
@@ -54,8 +54,7 @@ class COTR(nn.Module):
             s_t: float,
             egv: float,
             norm_s: bool,
-            det_train: bool,
-            is_zero_demo: bool
+            det_train: bool
     ):
 
         super(COTR, self).__init__()
@@ -135,8 +134,6 @@ class COTR(nn.Module):
                     torch.empty((self.num_objects, self.kernel_dim ** 2, emb_dim))
                 )
                 nn.init.normal_(self.objectness)
-        
-        self.is_zero_demo = is_zero_demo
 
     def clip_check_clusters(self, img, bboxes, category, img_name=None):
         bboxes = extend_bboxes(bboxes)
@@ -371,8 +368,7 @@ class COTR(nn.Module):
         return correlation_maps, outputs_R, outputR
 
     def forward(self, x_img, bboxes, name='', dmap=None, classes=None):
-        if not self.is_zero_demo:
-            self.num_objects = bboxes.shape[1]
+        self.num_objects = bboxes.shape[1]
         backbone_features = self.backbone(x_img)
         bs, _, bb_h, bb_w = backbone_features.size()
 
@@ -527,7 +523,7 @@ class COTR(nn.Module):
         return outputR, [], tblr, exemplar_bboxes
 
 
-def build_model(args, is_zero_demo=False):
+def build_model(args):
     return COTR(
         image_size=args.image_size,
         num_encoder_layers=args.num_enc_layers,
@@ -558,6 +554,5 @@ def build_model(args, is_zero_demo=False):
         norm_s=args.norm_s,
         egv=args.egv,
         prompt_shot=args.prompt_shot,
-        det_train=args.det_train,
-        is_zero_demo=is_zero_demo
+        det_train=args.det_train
     )

--- a/utils/data.py
+++ b/utils/data.py
@@ -7,9 +7,9 @@ import numpy as np
 from torch import Tensor
 from torch.utils.data import Dataset
 import torch
-import torchvision.transforms.functional as FT
 from torchvision import transforms as T
 from torchvision.transforms import functional as TVF
+
 
 def resize(img, bboxes):
     resize_img = T.Resize((512, 512), antialias=True)
@@ -45,6 +45,7 @@ def resize(img, bboxes):
     bboxes = bboxes * torch.tensor([scale_x, scale_y, scale_x, scale_y])
     return img, bboxes.float(), scale
 
+
 def pad_image(image_tensor):
     target_size = (512, 512)
     original_size = image_tensor.size()[1:]
@@ -52,7 +53,7 @@ def pad_image(image_tensor):
     # Calculate the amount of padding needed for each dimension
     pad_height = max(target_size[0] - original_size[0], 0)
     pad_width = max(target_size[1] - original_size[1], 0)
-    padded_image = FT.pad(image_tensor, (0, 0, pad_width, pad_height))
+    padded_image = TVF.pad(image_tensor, (0, 0, pad_width, pad_height))
     return padded_image
 
 
@@ -253,7 +254,6 @@ class FSC147WithDensityMapDOWNSIZE(Dataset):
             img_name = v["file_name"]
             map_name_2_id[img_name] = img_id
         return map_name_2_id
-
 
 
 def tiling_augmentation(img, bboxes, density_map, dmap, mask, resize, jitter, tile_size, hflip_p):


### PR DESCRIPTION
I propose a zero-shot demo that can be fully executed via command line.

You can run it with:
```
python demo_zero.py --img_path <input file or dir path> --out_path <output_path> --zero_shot --two_passes --skip_train --model_name DAVE_0_shot --model_path material --backbone resnet50 --swav_backbone --reduction 8 --num_enc_layers 3 --num_dec_layers 3 --kernel_dim 3 --emb_dim 256 --num_objects 3 --num_workers 8 --use_objectness --use_appearance --batch_size 1 --pre_norm
```
where:
- `--img_path` is the path of the image or directory of images to use as input;
- `--out_path` is the output path where the result(s) will be saved;
- `--two_passes` enables the 2-passes strategy as suggested by @jerpelhan in https://github.com/jerpelhan/DAVE/issues/5#issuecomment-2197006231.

If you prefer to show the result instead of saving it, just run:
```
python demo_zero.py --img_path <input file or dir path> --show --zero_shot --two_passes --skip_train --model_name DAVE_0_shot --model_path material --backbone resnet50 --swav_backbone --reduction 8 --num_enc_layers 3 --num_dec_layers 3 --kernel_dim 3 --emb_dim 256 --num_objects 3 --num_workers 8 --use_objectness --use_appearance --batch_size 1 --pre_norm
```
with `--show` instead of `--out_path`.